### PR TITLE
[PAGOPA-708] Bug Fix - Associazione multipla EC-canali e Canali-Tipo versamento

### DIFF
--- a/src/main/java/it/pagopa/pagopa/apiconfig/entity/CanaleTipoVersamento.java
+++ b/src/main/java/it/pagopa/pagopa/apiconfig/entity/CanaleTipoVersamento.java
@@ -20,6 +20,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import java.io.Serializable;
 import java.util.List;
 
@@ -29,7 +30,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 @Entity
-@Table(name = "CANALE_TIPO_VERSAMENTO", schema = "NODO4_CFG")
+@Table(name = "CANALE_TIPO_VERSAMENTO", schema = "NODO4_CFG", uniqueConstraints = { @UniqueConstraint(columnNames = { "FK_CANALE", "FK_TIPO_VERSAMENTO" }) })
 @Builder
 public class CanaleTipoVersamento implements Serializable {
     @Id

--- a/src/main/java/it/pagopa/pagopa/apiconfig/entity/PaStazionePa.java
+++ b/src/main/java/it/pagopa/pagopa/apiconfig/entity/PaStazionePa.java
@@ -20,8 +20,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
-@Table(name = "PA_STAZIONE_PA", schema = "NODO4_CFG")
+@Table(name = "PA_STAZIONE_PA", schema = "NODO4_CFG", uniqueConstraints = { @UniqueConstraint(columnNames = { "FK_PA", "FK_STAZIONE" }) })
 @Entity
 @Getter
 @Setter

--- a/src/main/java/it/pagopa/pagopa/apiconfig/exception/ErrorHandler.java
+++ b/src/main/java/it/pagopa/pagopa/apiconfig/exception/ErrorHandler.java
@@ -33,6 +33,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
     public static final String INTERNAL_SERVER_ERROR = "INTERNAL SERVER ERROR";
     public static final String BAD_REQUEST = "BAD REQUEST";
     public static final String FOREIGN_KEY_VIOLATION = "23503";
+  public static final String UNIQUE_INDEX_VIOLATION = "23505";
     public static final int CHILD_RECORD_VIOLATION = 2292;
 
 
@@ -133,7 +134,6 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-
     /**
      * @param ex      {@link DataIntegrityViolationException} exception raised when the SQL statement cannot be executed
      * @param request from frontend
@@ -142,7 +142,6 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler({DataIntegrityViolationException.class})
     public ResponseEntity<ProblemJson> handleDataIntegrityViolationException(final DataIntegrityViolationException ex, final WebRequest request) {
         ProblemJson errorResponse = null;
-
         if (ex.getCause() instanceof ConstraintViolationException) {
             String sqlState = ((ConstraintViolationException) ex.getCause()).getSQLState();
             var errorCode = ((ConstraintViolationException) ex.getCause()).getSQLException().getErrorCode();
@@ -163,6 +162,14 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
                         .title("Conflict with the current state of the resource")
                         .detail("There is a relation with other resource. Delete it first.")
                         .build();
+            }
+            if (UNIQUE_INDEX_VIOLATION.equals(sqlState)) {
+              log.warn("Can't insert in Database", ex);
+              errorResponse = ProblemJson.builder()
+                  .status(HttpStatus.CONFLICT.value())
+                  .title("Conflict with the current state of the resource")
+                  .detail("There is another relation with the same resource. Delete it first.")
+                  .build();
             }
         }
 

--- a/src/main/resources/h2/schema-h2.sql
+++ b/src/main/resources/h2/schema-h2.sql
@@ -130,7 +130,9 @@ create table NODO4_CFG.PA_STAZIONE_PA
             references NODO4_CFG.PA,
     constraint FK_PA_STAZIONE_PA_STAZIONE
         foreign key (FK_STAZIONE)
-            references NODO4_CFG.STAZIONI
+            references NODO4_CFG.STAZIONI,
+    constraint UQ_FK_PA_FK_STAZIONE
+        unique (FK_PA, FK_STAZIONE)
 );
 
 create table NODO4_CFG.CODIFICHE

--- a/src/main/resources/h2/schema-h2.sql
+++ b/src/main/resources/h2/schema-h2.sql
@@ -131,7 +131,7 @@ create table NODO4_CFG.PA_STAZIONE_PA
     constraint FK_PA_STAZIONE_PA_STAZIONE
         foreign key (FK_STAZIONE)
             references NODO4_CFG.STAZIONI,
-    constraint UQ_FK_PA_FK_STAZIONE
+    constraint UQ_PA_STAZIONE_PA
         unique (FK_PA, FK_STAZIONE)
 );
 
@@ -500,7 +500,9 @@ create table NODO4_CFG.CANALE_TIPO_VERSAMENTO
             references NODO4_CFG.CANALI,
     constraint FK_CANALE_TIPO_VERSAMENTO_TIPO_VERSAMENTO
         foreign key (FK_TIPO_VERSAMENTO)
-            references NODO4_CFG.TIPI_VERSAMENTO
+            references NODO4_CFG.TIPI_VERSAMENTO,
+    constraint UQ_CANALE_TIPO_VERSAMENTO
+        unique (FK_CANALE, FK_TIPO_VERSAMENTO)
 );
 
 create table NODO4_CFG.PSP_CANALE_TIPO_VERSAMENTO


### PR DESCRIPTION
With this pull request, there will be added two different unique constraint for the tables PA_STAZIONE_PA e CANALE_TIPO_VERSAMENTO. These constraints are required in order to resolve a bug for Channels and EC section on which is was possible to add two or more same relation simultaneously without blocking the duplication insertion.

#### List of Changes
 - Added JPA reference to the use of unique constraint for the table PA_STAZIONE_PA and its JPA Entity
 - Added JPA reference to the use of unique constraint for the table CANALE_TIPO_VERSAMENTO and its JPA Entity

#### Motivation and Context
This pull request resolve a bug on which it can be possible to insert simultaneously two or more duplicated elements without triggering applicative consistency checks.

#### How Has This Been Tested?
 - Tested in local environment with H2 database
Before testing in DEV, UAT and PROD environment, remember to apply the new unique constraints in Nodo4 DB.

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.