### PR TITLE
[PAGOPA-798] Fix: station-creditor institution relation

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "PagoPA API configuration",
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei Pagamenti",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.34.0-1-main"
+    "version": "0.34.1"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "PagoPA API configuration",
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei Pagamenti",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.34.1"
+    "version": "0.34.1-1-fix_station_creditorinstitution_relation"
   },
   "servers": [
     {

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -4,7 +4,7 @@
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei Pagamenti",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "PagoPA API configuration",
-    "version": "0.34.1"
+    "version": "0.34.1-1-fix_station_creditorinstitution_relation"
   },
   "host": "127.0.0.1:8080",
   "basePath": "/apiconfig/api/v1",

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -4,7 +4,7 @@
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei Pagamenti",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "PagoPA API configuration",
-    "version": "0.34.0-1-main"
+    "version": "0.34.1"
   },
   "host": "127.0.0.1:8080",
   "basePath": "/apiconfig/api/v1",

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>it.pagopa.pagopa.api-config</groupId>
   <artifactId>api-config</artifactId>
-  <version>0.34.0-1-main</version>
+  <version>0.34.1</version>
   <description>Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei
     Pagamenti
   </description>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>it.pagopa.pagopa.api-config</groupId>
   <artifactId>api-config</artifactId>
-  <version>0.34.1</version>
+  <version>0.34.1-1-fix_station_creditorinstitution_relation</version>
   <description>Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei
     Pagamenti
   </description>

--- a/src/main/java/it/pagopa/pagopa/apiconfig/service/StationsService.java
+++ b/src/main/java/it/pagopa/pagopa/apiconfig/service/StationsService.java
@@ -150,6 +150,7 @@ public class StationsService {
     return CommonUtil.createCsv(headers, csvRows);
   }
 
+  @Transactional(readOnly = true)
   public StationCreditorInstitution getStationCreditorInstitutionRelation(
       @NotNull String stationCode, @NotNull String creditorInstitutionCode) {
     // verify creditor institution


### PR DESCRIPTION
During a test session with GPD Payments, this service has called the API Config API with path `stations/{stationId}/creditorinstitutions/{creditorInstitutionId}` returned a 500 HTTP status code and an error message related to a invalid mapping operation. This was caused by an invalid Lazy Inizialization of EC relation in the retrieved entity.
With this commit, the Transaction annotation was added in order to widening the entity lifecycle and permits to execute a lazy inizialization of the entity without problem.

#### List of Changes
 - Added Transactional annotation on invoked service method 

#### Motivation and Context
As described up.

#### How Has This Been Tested?
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.