### PR TITLE
[PAGOPA-818] 🚀 feat(Dockerfile): add elastic-apm-agent to the contain…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN java -Djarmode=layertools -jar application.jar extract
 
 
 FROM ghcr.io/pagopa/docker-base-springboot-openjdk11:v1.0.1@sha256:bbbe948e91efa0a3e66d8f308047ec255f64898e7f9250bdb63985efd3a95dbf
+ADD --chown=spring:spring https://search.maven.org/remotecontent?filepath=co/elastic/apm/elastic-apm-agent/1.36.0/elastic-apm-agent-1.36.0.jar ./apm-elk-agent.jar
+
 COPY --chown=spring:spring  --from=builder dependencies/ ./
 COPY --chown=spring:spring  --from=builder snapshot-dependencies/ ./
 # https://github.com/moby/moby/issues/37965#issuecomment-426853382
@@ -21,3 +23,5 @@ COPY --chown=spring:spring  --from=builder spring-boot-loader/ ./
 COPY --chown=spring:spring  --from=builder application/ ./
 
 EXPOSE 8080
+
+ENTRYPOINT ["java","-javaagent:apm-elk-agent.jar","-javaagent:applicationinsights-agent.jar","org.springframework.boot.loader.JarLauncher"]

--- a/src/main/java/it/gov/pagopa/apiconfig/ApiConfig.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/ApiConfig.java
@@ -1,7 +1,6 @@
 package it.gov.pagopa.apiconfig;
 
 import java.util.Locale;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;


### PR DESCRIPTION
…er 🔧 chore(Dockerfile): update entrypoint to include elastic-apm-agent 🔧 chore(Dockerfile): update entrypoint to include applicationinsights-agent 🔧 chore(ApiConfig.java): remove unused import statement The elastic-apm-agent has been added to the container to allow for application performance monitoring. The entrypoint has been updated to include the elastic-apm-agent and applicationinsights-agent. The unused import statement has been removed from ApiConfig.java.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.