### PR TITLE
[PAGOPA-1087] fix: removing language checks on CDI upload

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "core",
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.50.3-1-main"
+    "version": "0.50.3-2-PAGOPA-1087-rimuovere-controlli-lingua-upload-cdi"
   },
   "servers": [
     {

--- a/openapi/openapi_auth.json
+++ b/openapi/openapi_auth.json
@@ -4,7 +4,7 @@
     "title": "core",
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.50.3-1-main"
+    "version": "0.50.3-2-PAGOPA-1087-rimuovere-controlli-lingua-upload-cdi"
   },
   "servers": [
     {

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -4,7 +4,7 @@
     "description": "Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "core",
-    "version": "0.50.3-1-main"
+    "version": "0.50.3-2-PAGOPA-1087-rimuovere-controlli-lingua-upload-cdi"
   },
   "host": "127.0.0.1:8080",
   "basePath": "/apiconfig/api/v1",

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>it.gov.pagopa.apiconfig</groupId>
   <artifactId>core</artifactId>
-  <version>0.50.3-1-main</version>
+  <version>0.50.3-2-PAGOPA-1087-rimuovere-controlli-lingua-upload-cdi</version>
   <description>Spring application exposes APIs to manage configuration for CI/PSP on the Nodo dei
     Pagamenti
   </description>

--- a/src/main/java/it/gov/pagopa/apiconfig/core/service/CdiService.java
+++ b/src/main/java/it/gov/pagopa/apiconfig/core/service/CdiService.java
@@ -367,8 +367,7 @@ public class CdiService {
       languages.add(informazioniServizio.getCodiceLingua());
     }
 
-    List<String> languagesTarget =
-        Stream.of("IT", "EN", "DE", "FR", "SL").collect(Collectors.toList());
+    List<String> languagesTarget = Stream.of("IT").collect(Collectors.toList());
     languagesTarget.removeAll(languages);
 
     final boolean[] duplicate = {false};

--- a/src/test/resources/file/cdi_not_valid_1.xml
+++ b/src/test/resources/file/cdi_not_valid_1.xml
@@ -32,13 +32,6 @@
             </identificazioneServizio>
             <listaInformazioniServizio>
                 <informazioniServizio>
-                    <codiceLingua>IT</codiceLingua>
-                    <descrizioneServizio>Clienti e non delle Banche possono disporre
-                        pagamenti con carte di pagamento VISA-MASTERCARD
-                    </descrizioneServizio>
-                    <disponibilitaServizio>7/7-24H</disponibilitaServizio>
-                </informazioniServizio>
-                <informazioniServizio>
                     <codiceLingua>EN</codiceLingua>
                     <descrizioneServizio>Both customers and non-customers may make card
                         payments with VISA-MASTERCARD


### PR DESCRIPTION
This PR contains some changes related to the language checks on CDI verification. In particular, the check on standard languages such as english, german, french and slovenian is removed, only allowing the constraint on italian language. This changes will not causes regression due to the fact that will only loose the existing constraint.

#### List of Changes
 - Loosening checks on language for CDI
 - Updated JUnit tests

#### Motivation and Context
This change is required in order to reduce the constraint of languages in CDI validation.

#### How Has This Been Tested?
 - Tested in local environment (via upload API and `/check` API)
 - Tested in DEV environment (only via `/check` API due to missing valid file relatable to existing CI)

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.